### PR TITLE
Implementation of idempotent key for all post requests

### DIFF
--- a/src/main/java/com/gocardless/http/ApiRequest.java
+++ b/src/main/java/com/gocardless/http/ApiRequest.java
@@ -1,11 +1,10 @@
 package com.gocardless.http;
 
+import com.google.common.collect.ImmutableMap;
+import com.squareup.okhttp.HttpUrl;
+
 import java.io.Reader;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
-
-import com.squareup.okhttp.HttpUrl;
 
 /**
  * Base class for API requests.
@@ -28,6 +27,10 @@ abstract class ApiRequest<T> {
     }
 
     Map<String, Object> getQueryParams() {
+        return ImmutableMap.of();
+    }
+
+    Map<String, String> getHeaders() {
         return ImmutableMap.of();
     }
 

--- a/src/main/java/com/gocardless/http/HttpClient.java
+++ b/src/main/java/com/gocardless/http/HttpClient.java
@@ -1,16 +1,19 @@
 package com.gocardless.http;
 
-import java.io.IOException;
-import java.io.Reader;
-import java.util.Map;
-
 import com.gocardless.GoCardlessException;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.Response;
 
-import com.squareup.okhttp.*;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Map;
 
 /**
  * An HTTP client that can execute {@link ApiRequest}s.
@@ -79,9 +82,8 @@ public class HttpClient {
                 new Request.Builder().url(url).header("Authorization", credentials)
                         .header("User-Agent", USER_AGENT)
                         .method(apiRequest.getMethod(), getBody(apiRequest));
-        for (Map.Entry<String, String> entry : HEADERS.entrySet()) {
-            request = request.header(entry.getKey(), entry.getValue());
-        }
+        request = addHeaderContent(request, HEADERS);
+        request = addHeaderContent(request, apiRequest.getHeaders());
         return request.build();
     }
 
@@ -128,6 +130,15 @@ public class HttpClient {
 
     private static String cleanUserAgentToken(String s) {
         return s.replaceAll(DISALLOWED_USER_AGENT_CHARACTERS, "_");
+    }
+
+    private static <T> Request.Builder addHeaderContent(Request.Builder request, Map<String, String> headers)
+    {
+        for (Map.Entry<String, String> entry : headers.entrySet())
+        {
+            request = request.header(entry.getKey(), entry.getValue());
+        }
+        return request;
     }
 
     @VisibleForTesting

--- a/src/main/java/com/gocardless/http/PostRequest.java
+++ b/src/main/java/com/gocardless/http/PostRequest.java
@@ -1,6 +1,10 @@
 package com.gocardless.http;
 
+import com.google.common.collect.ImmutableMap;
+
 import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Base class for POST requests.
@@ -8,6 +12,8 @@ import java.io.Reader;
  * @param <T> the type of the item returned by this request.
  */
 public abstract class PostRequest<T> extends ApiRequest<T> {
+    private final Map<String, String> headers = new HashMap<>();
+
     protected PostRequest(HttpClient httpClient) {
         super(httpClient);
     }
@@ -35,6 +41,12 @@ public abstract class PostRequest<T> extends ApiRequest<T> {
         return getHttpClient().executeWrapped(this);
     }
 
+    public PostRequest<T> withIdempotentKey(final String key)
+    {
+        headers.put("Idempotency-Key", key);
+        return this;
+    }
+
     @Override
     protected T parseResponse(Reader stream, ResponseParser responseParser) {
         return responseParser.parseSingle(stream, getEnvelope(), getResponseClass());
@@ -43,6 +55,12 @@ public abstract class PostRequest<T> extends ApiRequest<T> {
     @Override
     protected final String getMethod() {
         return "POST";
+    }
+
+    @Override
+    Map<String, String> getHeaders()
+    {
+        return ImmutableMap.copyOf(headers);
     }
 
     protected abstract Class<T> getResponseClass();

--- a/src/main/java/com/gocardless/http/PostRequest.java
+++ b/src/main/java/com/gocardless/http/PostRequest.java
@@ -12,7 +12,7 @@ import java.util.Map;
  * @param <T> the type of the item returned by this request.
  */
 public abstract class PostRequest<T> extends ApiRequest<T> {
-    private final Map<String, String> headers = new HashMap<>();
+    private final transient Map<String, String> headers = new HashMap<>();
 
     protected PostRequest(HttpClient httpClient) {
         super(httpClient);


### PR DESCRIPTION
This is a basic implementation of having the idempotent key in the header of a post request to resolve #4 

I'm not overly comfortable with the map living within the PostRequest object (but I'm not a huge fan of inheritance anyway), but the whole concept of idempotency is an attribute of POST rather than any request that implements it so shouldn't go any lower.