### PR TITLE
Release 5.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ With Maven:
 <dependency>
     <groupId>com.gocardless</groupId>
     <artifactId>gocardless-pro</artifactId>
-    <version>5.10.0</version>
+    <version>5.11.0</version>
 </dependency>
 ```
 
 With Gradle:
 
 ```
-compile 'com.gocardless:gocardless-pro:5.10.0'
+compile 'com.gocardless:gocardless-pro:5.11.0'
 ```
 
 ## Initializing the client

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ plugins {
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 group = 'com.gocardless'
-version = '5.10.0'
+version = '5.11.0'
 
 apply plugin: 'ch.raffael.pegdown-doclet'
 

--- a/src/main/java/com/gocardless/http/HttpClient.java
+++ b/src/main/java/com/gocardless/http/HttpClient.java
@@ -35,7 +35,7 @@ public class HttpClient {
     private static final String DISALLOWED_USER_AGENT_CHARACTERS =
             "[^\\w!#$%&'\\*\\+\\-\\.\\^`\\|~]";
     private static final String USER_AGENT =
-            String.format("gocardless-pro-java/5.10.0 java/%s %s/%s %s/%s",
+            String.format("gocardless-pro-java/5.11.0 java/%s %s/%s %s/%s",
                     cleanUserAgentToken(System.getProperty("java.vm.specification.version")),
                     cleanUserAgentToken(System.getProperty("java.vm.name")),
                     cleanUserAgentToken(System.getProperty("java.version")),
@@ -48,7 +48,7 @@ public class HttpClient {
         ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
         builder.put("GoCardless-Version", "2015-07-06");
         builder.put("GoCardless-Client-Library", "gocardless-pro-java");
-        builder.put("GoCardless-Client-Version", "5.10.0");
+        builder.put("GoCardless-Client-Version", "5.11.0");
         HEADERS = builder.build();
     }
     private final OkHttpClient rawClient;

--- a/src/main/java/com/gocardless/services/BlockService.java
+++ b/src/main/java/com/gocardless/services/BlockService.java
@@ -536,7 +536,7 @@ public class BlockService {
 
         @Override
         protected String getPathTemplate() {
-            return "block_by_ref";
+            return "blocks/block_by_ref";
         }
 
         @Override

--- a/src/test/java/com/gocardless/GoCardlessClientTest.java
+++ b/src/test/java/com/gocardless/GoCardlessClientTest.java
@@ -315,7 +315,7 @@ public class GoCardlessClientTest {
         assertThat(blocks.get(0).getBlockType()).isEqualTo(Block.BlockType.EMAIL);
         assertThat(blocks.get(1).getId()).isEqualTo("BLC456");
         assertThat(blocks.get(1).getBlockType()).isEqualTo(Block.BlockType.BANK_ACCOUNT);
-        http.assertRequestMade("POST", "/block_by_ref",
+        http.assertRequestMade("POST", "/blocks/block_by_ref",
                 "fixtures/client/create_blocks_by_ref_request.json",
                 ImmutableMap.of("Authorization", "Bearer " + ACCESS_TOKEN));
     }


### PR DESCRIPTION
Update version to include:
- Making `creditor_type` and `country_code` required when creating creditors via the API (for payment providers);
- Removing `null` as an allowed value for `creditor_type` when creating creditors.