### PR TITLE
Use the correct token for triggering publish

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -42,4 +42,4 @@ jobs:
           git push origin v${{ steps.version.outputs.version }}
           gh release create v${{ steps.version.outputs.version }} --generate-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GOCARDLESS_CI_ROBOT_TOKEN }}


### PR DESCRIPTION
The last time a version bump was merged, it created the git tag and github release, but it didn't trigger the maven-publish.yml flow to publish it to maven.

I think this is because it used the standard GITHUB_TOKEN which can't trigger workflows. By using the GOCARDLESS_CI_ROBOT_TOKEN Personal Access Token, we can trigger workflows.