### PR TITLE
Include HTTP status code in MalformedResponseException

### DIFF
--- a/src/main/java/com/gocardless/errors/MalformedResponseException.java
+++ b/src/main/java/com/gocardless/errors/MalformedResponseException.java
@@ -7,14 +7,43 @@ import com.gocardless.GoCardlessException;
  * HTML error page returned from a load balancer)
  */
 public class MalformedResponseException extends GoCardlessException {
+    private static final int UNKNOWN_STATUS_CODE = -1;
+    private static final int BODY_PREVIEW_MAX_LENGTH = 500;
+    private final int statusCode;
     private final String responseBody;
 
     public MalformedResponseException(String responseBody) {
-        super("Malformed response received from server");
+        this(UNKNOWN_STATUS_CODE, responseBody);
+    }
+
+    public MalformedResponseException(int statusCode, String responseBody) {
+        super(buildMessage(statusCode, responseBody));
+        this.statusCode = statusCode;
         this.responseBody = responseBody;
+    }
+
+    /**
+     * @return the HTTP status code of the malformed response, or -1 if unknown.
+     */
+    public int getStatusCode() {
+        return statusCode;
     }
 
     public String getResponseBody() {
         return responseBody;
+    }
+
+    private static String buildMessage(int statusCode, String responseBody) {
+        StringBuilder message = new StringBuilder("Malformed response received from server");
+        if (statusCode != UNKNOWN_STATUS_CODE) {
+            message.append(" (HTTP ").append(statusCode).append(")");
+        }
+        if (responseBody != null && !responseBody.isEmpty()) {
+            String preview = responseBody.length() > BODY_PREVIEW_MAX_LENGTH
+                    ? responseBody.substring(0, BODY_PREVIEW_MAX_LENGTH) + "..."
+                    : responseBody;
+            message.append(": ").append(preview);
+        }
+        return message.toString();
     }
 }

--- a/src/main/java/com/gocardless/http/ResponseParser.java
+++ b/src/main/java/com/gocardless/http/ResponseParser.java
@@ -56,15 +56,22 @@ final class ResponseParser {
         try {
             json = new JsonParser().parse(responseBody);
         } catch (JsonSyntaxException e) {
-            throw new MalformedResponseException(responseBody);
+            throw new MalformedResponseException(statusCode, responseBody);
         }
-        JsonElement errorElement = json.getAsJsonObject().get("error");
-        if (errorElement.isJsonPrimitive()) {
-            ApiErrorResponse error =
-                    ApiErrorResponse.fromMessage(errorElement.getAsString(), statusCode);
+        try {
+            JsonElement errorElement = json.getAsJsonObject().get("error");
+            if (errorElement == null || errorElement.isJsonNull()) {
+                throw new MalformedResponseException(statusCode, responseBody);
+            }
+            if (errorElement.isJsonPrimitive()) {
+                ApiErrorResponse error =
+                        ApiErrorResponse.fromMessage(errorElement.getAsString(), statusCode);
+                return GoCardlessErrorMapper.toException(error);
+            }
+            ApiErrorResponse error = gson.fromJson(errorElement, ApiErrorResponse.class);
             return GoCardlessErrorMapper.toException(error);
+        } catch (IllegalStateException | ClassCastException | JsonSyntaxException e) {
+            throw new MalformedResponseException(statusCode, responseBody);
         }
-        ApiErrorResponse error = gson.fromJson(errorElement, ApiErrorResponse.class);
-        return GoCardlessErrorMapper.toException(error);
     }
 }

--- a/src/test/java/com/gocardless/http/ResponseParserTest.java
+++ b/src/test/java/com/gocardless/http/ResponseParserTest.java
@@ -167,6 +167,20 @@ public class ResponseParserTest {
     }
 
     @Test
+    public void shouldIncludeStatusCodeAndBodyForNonJsonErrorResponse() throws IOException {
+        URL resource = Resources.getResource("fixtures/non_json_response.html");
+        String responseBody = Resources.toString(resource, UTF_8);
+        try {
+            parser.parseError(responseBody, 502);
+            org.junit.Assert.fail("expected MalformedResponseException");
+        } catch (MalformedResponseException e) {
+            assertThat(e.getStatusCode()).isEqualTo(502);
+            assertThat(e.getResponseBody()).isEqualTo(responseBody);
+            assertThat(e.getMessage()).contains("HTTP 502");
+        }
+    }
+
+    @Test
     public void shouldHandleAuthenticationError() throws IOException {
         URL resource = Resources.getResource("fixtures/unauthorized_error.json");
         String responseBody = Resources.toString(resource, UTF_8);


### PR DESCRIPTION
  When the API returns a non-2xx response with a body that isn't a valid
  JSON error envelope (e.g. an HTML page from Cloudflare), the SDK
  previously threw MalformedResponseException with no indication of the
  underlying HTTP status, making it hard to distinguish a WAF 403 from
  an edge 5xx during triage.

  Expose the status code via getStatusCode() and include it in the
  exception message alongside a truncated body preview.