### PR TITLE
Add all-tests-passed aggregator job to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,3 +42,16 @@ jobs:
           name: test_library_jdk${{ matrix.jdk-version }}_junit
           path: "~/junit"
           retention-days: 7
+
+  all-tests-passed:
+    name: All tests passed
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
+      - name: Check test job status
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "test job did not succeed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds an `all-tests-passed` job that depends on the whole `test` matrix (5 JDK versions) and fails if any entry didn't succeed.

## Why
Part of IX-2323: setting up required status checks across GoCardless's public client library repos so we can safely enable auto-merge. The `test` matrix produces one check per JDK version, which is brittle to require individually in branch protection since the list shifts whenever a JDK version is added or dropped. `all-tests-passed` gives branch protection a single stable check name to require instead.

## Test plan
- [x] Confirm `all-tests-passed` appears and passes on this PR