### PR TITLE
Use knope-dev proxy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      - uses: knope-dev/action@v2.1.2
+      - uses: gocardless/github-actions/proxies/knope-dev-action@master
         with:
           version: 0.23.0
       - run: knope release --verbose


### PR DESCRIPTION
The GitHub org security settings don't have this in their allowlist, so I've added a proxy to our gocardless/github-actions repo, which is allowed.