### PR TITLE
Fix duplicate releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -37,7 +37,7 @@ jobs:
         id: notes
         if: steps.check.outputs.should_release == 'true'
         run: |
-          VERSION="${{ steps.check.outputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
           NOTES=""
           if [ -f CHANGELOG.md ]; then
             NOTES=$(awk -v ver="$VERSION" '


### PR DESCRIPTION
When a change was pushed down from client-library-templates, the flow in here created 3 releases instead of 1.

They also had the description repeated within each release.

This is because:
- `steps.check.outputs.version` doesn't exist — the `check` step only outputs `should_release`. The version comes from the `version` step (`steps.version.outputs.version`), which is already referenced correctly elsewhere in this file.
- With `VERSION` empty, the awk extraction's start pattern (`^## ` + empty string) matched every version header in CHANGELOG.md, and `next` fired before the exit rule ever got a chance to run, so notes from older releases kept bleeding into newer ones.
